### PR TITLE
Remove trailing space so that Babel doesn't complain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ exports.run = async (browser) => {
   await page.type('#lst-ib', 'aaaaa');
   // avoid to timeout waitForNavigation() after click()
   await Promise.all([
-    // avoid to 
+    // avoid to
     // 'Cannot find context with specified id undefined' for localStorage
     page.waitForNavigation(),
     page.click('[name=btnK]'),


### PR DESCRIPTION
Without this change, serverless deploy fails, on eslint src, which in turn says:

/src/index.js
  26:16  error  Trailing spaces not allowed  no-trailing-spaces