### PR TITLE
Lambda requires json as response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,5 +55,8 @@ exports.run = async (browser) => {
     return localStorage.getItem('name');
   }));
   await page.close();
-  return 'done';
+  
+  return JSON.stringify({
+    success: true,
+  });
 };


### PR DESCRIPTION
Returning a string was causing "Internal server error", since lambda requires JSON as a response. 

https://forums.aws.amazon.com/thread.jspa?threadID=244538