### PR TITLE
 Add Dockerfile build Lambda environment for test

### DIFF
--- a/.aws/config
+++ b/.aws/config
@@ -1,0 +1,4 @@
+[default]
+region = us-east-1
+
+

--- a/.aws/credentials
+++ b/.aws/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = <your aws_access_key_id>
+aws_secret_access_key = <your aws_secret_access_key>

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,8 @@ module.exports = {
     "extends": "google",
     "parserOptions": {
     	"ecmaVersion": 2017,
+    },
+    "rules":{
+    	 "linebreak-style": [0 ,"error", "windows"]
     }
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM amazonlinux:2017.03.1.20170812
+RUN yum install -y aws-cli
+RUN yum groupinstall -y 'Development Tools'
+RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+RUN yum -y install nodejs-6.10.3
+ADD ./.aws /root/.aws
+RUN npm install serverless -g
+WORKDIR /start-kit

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ If you want to use latest chrome, run chrome/buildChrome.sh on EC2 having at lea
 See also [serverless-chrome](https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md).
 Once you build it, link to `headless_shell.tar.gz` in `chrome` dir.
 
+## Build Lambda environment by docker (optional)
+
+Amazon provider docker image in dokcer store ,it can build Lambda environment for test 
+[https://store.docker.com/images/amazonlinux]
+
+1. install docker & docker-compose 
+- docker  [https://docs.docker.com/install/]
+- docker-compose [https://docs.docker.com/compose/install/#master-builds]
+2. setup aws credentials in `.aws` folder
+3. `docker-compose up`
+4. `docker-compose exec lambda-env bash`
+5. `cd /start-kit`
+6. `npm install `
+7. start to test
+
 ## Article
 
 [Lambda上でPuppeteer/Headless Chromeを動かすStarter Kitを作った - sambaiz-net](https://www.sambaiz.net/article/132/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Amazon provider docker image in dokcer store ,it can build Lambda environment fo
 - docker  [https://docs.docker.com/install/]
 - docker-compose [https://docs.docker.com/compose/install/#master-builds]
 2. setup aws credentials in `.aws` folder
-3. `docker-compose up`
+3. `docker-compose up --build`
 4. `docker-compose exec lambda-env bash`
 5. `cd /start-kit`
 6. `npm install `

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   lambda-env:
     build: .
-    image:  yc/aws-lambda-env-2018:latest
+    image:  startkit/aws-lambda-env-2018:latest
     command:  node
     volumes:
       - ./:/start-kit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  lambda-env:
+    build: .
+    image:  yc/aws-lambda-env-2018:latest
+    command:  node
+    volumes:
+      - ./:/start-kit
+    stdin_open: true
+    tty: true  


### PR DESCRIPTION
Amazon provider docker image in dokcer store ,it can build Lambda current environment 
[https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/current-supported-versions.html]
lets easy to test serverless function.