### PR TITLE
Update npm-scripts to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.1.2",
   "description": "Starter Kit for running Headless-Chrome by Puppeteer on AWS Lambda",
   "scripts": {
-    "package": "npm run package-prepare && cp chrome/headless_shell.tar.gz dist && cd dist && zip -rq ../package.zip .",
-    "package-nochrome": "npm run package-prepare && cd dist && zip -rq ../package.zip .",
-    "package-prepare": "npm run lint && npm run babel && cp -r package.json dist && cd dist && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install --production",
-    "babel": "rm -rf dist && mkdir dist && ./node_modules/.bin/babel src --out-dir dist",
-    "local": "npm run babel && cp -r node_modules dist && node dist/starter-kit/local.js",
-    "lint": "./node_modules/.bin/eslint src"
+    "package": "npm run package-prepare && cpy chrome/headless_shell.tar.gz dist && cross-zip ./dist ./package.zip",
+    "package-nochrome": "npm run package-prepare && cross-zip ./dist ./package.zip",
+    "package-prepare": "npm run lint && npm run babel && cpy package.json dist && cd dist && npm config set PUPPETEER_SKIP_CHROMIUM_DOWNLOAD 1 && npm install --production && npm config rm PUPPETEER_SKIP_CHROMIUM_DOWNLOAD",
+    "babel": "rimraf dist && mkdirp dist && babel src --out-dir dist",
+    "local": "npm run babel && cpy node_modules dist && node dist/starter-kit/local.js",
+    "lint": "eslint src"
   },
   "dependencies": {
     "puppeteer": "^1.1.1",
@@ -18,8 +18,12 @@
     "aws-sdk": "^2.111.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "cpy-cli": "^2.0.0",
+    "cross-zip-cli": "^1.0.0",
     "eslint": "^4.6.1",
     "eslint-config-google": "^0.9.1",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.2",
     "serverless-hooks-plugin": "^1.1.0"
   }
 }


### PR DESCRIPTION
This pull-request removes all Unix-specific commands from the NPM-scripts and replace them with cross-platform commands, thereby allowing this project to built on Windows.

I have tested these changes on Windows and they produce a package.zip.
Since I currently do not have access to a Unix-system I can neither verify if the changes also altered the behaviour nor if this is still working on Unix, so this should be tested before merging.

Fixes #6 and fixes #14.