### PR TITLE
pin puppeteer version to v1.3.0, to match the bundled headless chrome v67

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "./node_modules/.bin/eslint src"
   },
   "dependencies": {
-    "puppeteer": "^1.1.1",
+    "puppeteer": "=1.3.0",
     "tar": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I downloaded a fresh copy of this starter kit and tried to run it. In AWS, it timed out. Puppeteer versions later than 1.3.0 expect a more recent version of chrome than the v67 that is bundled in the repo at the moment. This mismatch of puppeteer version causes the starter kit to appear to hang on the page.newPage() call.

By pining the version to v1.3.0 of puppeteer, the starter kit works again.

I am going to create some more pull requests next to upgrade the starter kit to nodejs v8.10, now that v6.10 on AWS Lambda will be end of life by 30 April 2019. Reference: https://github.com/apex/up/issues/763.

I will also create a pull request to use the chrome binary from https://github.com/alixaxel/chrome-aws-lambda, as this binary is created in lock-step with puppeteer releases specifically for AWS lambda.

I'm breaking these changes up into multiple pull requests to keep them small and easy to comprehend.